### PR TITLE
fix in acodec special treatment

### DIFF
--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -1128,16 +1128,25 @@ def video_text_fields(image, draw, layout, info, dynamic=False):
 
         # special treatment for audio codec, which gets a lookup
         if field_info["name"] == "acodec":
-            if info['VideoPlayer.Codec'] in codec_name.keys():
+            if info['VideoPlayer.AudioCodec'] in codec_name.keys():
                 # render any label first
                 if "label" in field_info:
                     draw.text((field_info["lposx"], field_info["lposy"]),
                               field_info["label"],
                               fill=field_info["lfill"], font=field_info["lfont"])
                 draw.text((field_info["posx"], field_info["posy"]),
-                          codec_name[info['VideoPlayer.Codec']],
+                          codec_name[info['VideoPlayer.AudioCodec']],
                           fill=field_info["fill"],
                           font=field_info["font"])
+            else:
+               # render any label first
+               if "label" in field_info:
+                   draw.text((field_info["lposx"], field_info["lposy"]),
+                   field_info["label"],
+                   fill=field_info["lfill"], font=field_info["lfont"])
+               draw.text((field_info["posx"], field_info["posy"]),
+               info['VideoPlayer.AudioCodec'], fill=field_info["fill"],
+               font=field_info["font"])
 
         # all other text fields
         else:


### PR DESCRIPTION
VideoPlayer.Codec info labeldoes not exist
use  VideoPlayer.AudioCodec instead

also send back the raw name if codec not in the codec_name table

